### PR TITLE
Add packages.txt with libgl1-mesa-glx dependency

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,1 @@
+libgl1-mesa-glx


### PR DESCRIPTION
Introduces a new packages.txt file listing libgl1-mesa-glx as a required package. for Linux server in streamlit